### PR TITLE
Feature/add api key management

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -5,6 +5,7 @@ import errorHandler from './middlewares/errorHandler.js'
 import userRoutes from './routes/user.routes.js'
 import leadRoutes from './routes/lead.routes.js'
 import passwordRoutes from './routes/password.routes.js'
+import apikeyRoutes from './routes/apikey.routes.js'
 
 const app = express();
 
@@ -17,6 +18,7 @@ app.use(morgan('dev'))
 app.use('/api/users', userRoutes); 
 app.use('/api/leads', leadRoutes);
 app.use('/api/password', passwordRoutes);
+app.use('/api/apikey', apikeyRoutes);
 
 //error handler
 app.use(errorHandler);

--- a/server/src/controllers/apikey.controller.js
+++ b/server/src/controllers/apikey.controller.js
@@ -40,12 +40,70 @@ const generateApiKey = async (req, res) => {
     }
 };
 
-/* 
-revoke apikey
-activate apikey
-regenerate apikey
-*/
+const toggleApiKeyStatus = async (req, res) => {
+    try {
+        
+        const apiKey = req.apiKey;
+
+        // Toggle the revoked status
+        apiKey.revoked = !apiKey.revoked;
+        await apiKey.save();
+
+        res.status(200).json({
+            success: true,
+            message: `API key ${apiKey.revoked ? 'revoked' : 'activated'} successfully`,
+            data: apiKey
+        });
+
+    } catch (error) {
+        console.error('Toggle API key status error:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Failed to toggle API key status'
+        });
+    }
+};
+
+const regenerateApiKey = async (req, res) => {
+    try {
+        const apiKey = req.apiKey;
+        const { expiresAt } = req.body;
+
+        // Generate a new secure random API key
+        const apiKeyBuffer = crypto.randomBytes(32);
+        const newKey = apiKeyBuffer.toString('base64url');
+
+        // Update the existing API key with new key and expiration
+        apiKey.key = newKey;
+        apiKey.expiresAt = new Date(expiresAt);
+        apiKey.revoked = false; // Reset revoked status
+        await apiKey.save();
+
+        // Don't send the actual key in the response data for security
+        const apiKeyData = apiKey.toObject();
+        delete apiKeyData.key;
+
+        res.status(200).json({
+            success: true,
+            message: 'API key regenerated successfully',
+            data: {
+                ...apiKeyData,
+                key: newKey // Send new key only once in the response
+            }
+        });
+
+    } catch (error) {
+        console.error('Regenerate API key error:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Failed to regenerate API key'
+        });
+    }
+};
+
 
 export {
-    generateApiKey
+    generateApiKey,
+    toggleApiKeyStatus,
+    regenerateApiKey
 };

--- a/server/src/controllers/apikey.controller.js
+++ b/server/src/controllers/apikey.controller.js
@@ -1,0 +1,51 @@
+import crypto from 'crypto';
+import ApiKey from '../models/ApiKey.js';
+
+const generateApiKey = async (req, res) => {
+    try {
+        // Client is already validated and attached to request by middleware
+        const client = req.client;
+        const { expiresAt } = req.body;
+
+        // Generate a secure random API key
+        const apiKeyBuffer = crypto.randomBytes(32);
+        const apiKey = apiKeyBuffer.toString('base64url');
+
+        // Create new API key record
+        const newApiKey = await ApiKey.create({
+            clientId: client._id,
+            key: apiKey,
+            expiresAt: new Date(expiresAt)
+        });
+
+        // Don't send the actual key in the response data for security
+        const apiKeyData = newApiKey.toObject();
+        delete apiKeyData.key;
+
+        res.status(201).json({
+            success: true,
+            message: 'API key generated successfully',
+            data: {
+                ...apiKeyData,
+                key: apiKey // Send key only once in the response
+            }
+        });
+
+    } catch (error) {
+        console.error('Generate API key error:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Failed to generate API key'
+        });
+    }
+};
+
+/* 
+revoke apikey
+activate apikey
+regenerate apikey
+*/
+
+export {
+    generateApiKey
+};

--- a/server/src/middlewares/validation/ApiKeyValidation.js
+++ b/server/src/middlewares/validation/ApiKeyValidation.js
@@ -67,6 +67,77 @@ const generateApiKeyValidation = [
         })
 ];
 
+const toggleApiKeyStatusValidation = [
+    param('apiKeyId')
+        .trim()
+        .notEmpty()
+        .withMessage('API Key ID is required')
+        .custom(async (apiKeyId, { req }) => {
+            try {
+                const apiKey = await ApiKey.findById(apiKeyId);
+                if (!apiKey) {
+                    throw new Error('API key not found');
+                }
+                req.apiKey = apiKey;
+                return true;
+            } catch (error) {
+                if (error.name === 'CastError') {
+                    throw new Error('Invalid API key ID format');
+                }
+                throw error;
+            }
+        })
+];
+
+const regenerateApiKeyValidation = [
+    param('apiKeyId')
+        .trim()
+        .notEmpty()
+        .withMessage('API Key ID is required')
+        .custom(async (apiKeyId, { req }) => {
+            try {
+                const apiKey = await ApiKey.findById(apiKeyId);
+                if (!apiKey) {
+                    throw new Error('API key not found');
+                }
+                req.apiKey = apiKey;
+                return true;
+            } catch (error) {
+                if (error.name === 'CastError') {
+                    throw new Error('Invalid API key ID format');
+                }
+                throw error;
+            }
+        }),
+    body('expiresAt')
+        .trim()
+        .notEmpty()
+        .withMessage('Expiration date is required')
+        .isISO8601()
+        .withMessage('Invalid date format. Please use ISO 8601 format (YYYY-MM-DD)')
+        .custom((value) => {
+            const expirationDate = new Date(value);
+            const now = new Date();
+
+            // Check if date is in the future
+            if (expirationDate <= now) {
+                throw new Error('Expiration date must be in the future');
+            }
+
+            // Check if date is not more than 1 year from now
+            const oneYearFromNow = new Date();
+            oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
+            
+            if (expirationDate > oneYearFromNow) {
+                throw new Error('Expiration date cannot be more than 1 year from now');
+            }
+
+            return true;
+        })
+];
+
 export {
-    generateApiKeyValidation
+    generateApiKeyValidation,
+    toggleApiKeyStatusValidation,
+    regenerateApiKeyValidation
 }

--- a/server/src/middlewares/validation/ApiKeyValidation.js
+++ b/server/src/middlewares/validation/ApiKeyValidation.js
@@ -1,0 +1,72 @@
+import { param, body } from 'express-validator';
+import User from '../../models/User.js';
+import ApiKey from '../../models/ApiKey.js';
+
+const generateApiKeyValidation = [
+    param('clientId')
+        .trim()
+        .notEmpty()
+        .withMessage('Client ID is required')
+        .custom(async (clientId, { req }) => {
+            try {
+                // Check if client exists and is active
+                const client = await User.findOne({ 
+                    _id: clientId,
+                    role: 'client',
+                    isEmailVerified: true
+                });
+
+                if (!client) {
+                    throw new Error('Client not found or not verified');
+                }
+
+                // Check if client already has an active API key
+                const existingApiKey = await ApiKey.findOne({
+                    clientId: client._id,
+                    expiresAt: { $gt: new Date() }
+                });
+
+                if (existingApiKey) {
+                    throw new Error('Client already has an active API key');
+                }
+
+                // Store client in request for controller use
+                req.client = client;
+                return true;
+            } catch (error) {
+                if (error.name === 'CastError') {
+                    throw new Error('Invalid client ID format');
+                }
+                throw error;
+            }
+        }),
+    body('expiresAt')
+        .trim()
+        .notEmpty()
+        .withMessage('Expiration date is required')
+        .isISO8601()
+        .withMessage('Invalid date format. Please use ISO 8601 format (YYYY-MM-DD)')
+        .custom((value) => {
+            const expirationDate = new Date(value);
+            const now = new Date();
+
+            // Check if date is in the future
+            if (expirationDate <= now) {
+                throw new Error('Expiration date must be in the future');
+            }
+
+            // Check if date is not more than 1 year from now
+            const oneYearFromNow = new Date();
+            oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
+            
+            if (expirationDate > oneYearFromNow) {
+                throw new Error('Expiration date cannot be more than 1 year from now');
+            }
+
+            return true;
+        })
+];
+
+export {
+    generateApiKeyValidation
+}

--- a/server/src/routes/apikey.routes.js
+++ b/server/src/routes/apikey.routes.js
@@ -2,12 +2,14 @@ import express from 'express';
 import validate from '../middlewares/validate.js';
 import verifyToken from '../middlewares/verifyToken.js';
 import verifyRole from '../middlewares/verifyRole.js';
-import { generateApiKey } from '../controllers/apikey.controller.js';
-import { generateApiKeyValidation } from '../middlewares/validation/ApiKeyValidation.js';
+import { generateApiKey, toggleApiKeyStatus, regenerateApiKey } from '../controllers/apikey.controller.js';
+import { generateApiKeyValidation, toggleApiKeyStatusValidation, regenerateApiKeyValidation } from '../middlewares/validation/ApiKeyValidation.js';
 
 const router = express.Router();
 
 // API Key Routes
 router.post('/:clientId', verifyToken, verifyRole(['admin']), generateApiKeyValidation, validate, generateApiKey);
+router.patch('/:apiKeyId', verifyToken, verifyRole(['admin']), toggleApiKeyStatusValidation, validate, toggleApiKeyStatus);
+router.patch('/:apiKeyId/regenerate', verifyToken, verifyRole(['admin']), regenerateApiKeyValidation, validate, regenerateApiKey);
 
 export default router;

--- a/server/src/routes/apikey.routes.js
+++ b/server/src/routes/apikey.routes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import validate from '../middlewares/validate.js';
+import verifyToken from '../middlewares/verifyToken.js';
+import verifyRole from '../middlewares/verifyRole.js';
+import { generateApiKey } from '../controllers/apikey.controller.js';
+import { generateApiKeyValidation } from '../middlewares/validation/ApiKeyValidation.js';
+
+const router = express.Router();
+
+// API Key Routes
+router.post('/:clientId', verifyToken, verifyRole(['admin']), generateApiKeyValidation, validate, generateApiKey);
+
+export default router;


### PR DESCRIPTION
This PR adds full API key management functionality for admins, including:
    -✅ Generate API Key for a specific client (with expiration support)
    -🔄 Toggle API Key Status: Revoke or activate an API key
    -♻️ Regenerate API Key: Replaces the old key with a new one and resets the expiration

Key Implementation Details:
    -Introduced a new Mongoose ApiKey model
    -Protected all API key routes with admin authorization
    -Ensured regenerated keys are unique and return the updated key to the admin
    -Added validations for expiration and client ownership